### PR TITLE
Auto publish module to secretflow/bazel-registry

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,7 @@
+{
+  "homepage": "https://github.com/secretflow/psi",
+  "maintainers": [],
+  "repository": ["github:secretflow/psi"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@psi//psi/..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{TAG}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}


### PR DESCRIPTION
Include .bcr template files to enable automate publishing module to bazel-registry